### PR TITLE
Authentication functions should be private

### DIFF
--- a/src/girajira/jira/authentication.clj
+++ b/src/girajira/jira/authentication.clj
@@ -1,15 +1,15 @@
 (ns girajira.jira.authentication
   (:require [girajira.config :as config]))
 
-(defn base-url
+(defn- base-url
   [secrets]
   (:jira-url secrets))
 
-(defn username
+(defn- username
   [secrets]
   (:jira-user secrets))
 
-(defn password
+(defn- password
   [secrets]
   (:jira-pass secrets))
 

--- a/test/girajira/jira/authentication_test.clj
+++ b/test/girajira/jira/authentication_test.clj
@@ -8,12 +8,6 @@
    :jira-user "some user"
    :jira-pass "mypassword"})
 
-(fact "returns a jira username from given secrets"
-  (username secrets) => "some user")
-
-(fact "returns a jira password from given secrets"
-  (password secrets) => "mypassword")
-
 (fact "returns a jira url from given secrets"
   (url) => "www.jira.com"
   (provided (config/secrets) => secrets))


### PR DESCRIPTION
## Why?

Several private authentication helper functions are accessible from other namespaces.

## Changes
- Remove tests that verify behavior of private functions
- Make functions private

  