### PR TITLE
Refactor jira namespace to integrations

### DIFF
--- a/src/girajira/api/github/move_jira_issue.clj
+++ b/src/girajira/api/github/move_jira_issue.clj
@@ -1,5 +1,5 @@
 (ns girajira.api.github.move-jira-issue
-  (:require [girajira.jira.transitions :as jira]))
+  (:require [girajira.integrations.jira.transitions :as jira]))
 
 (defn- move-to-column
   [issue column]

--- a/src/girajira/config.clj
+++ b/src/girajira/config.clj
@@ -4,4 +4,3 @@
 (defn secrets
   []
   (aero/read-config "config/.config.edn"))
-

--- a/src/girajira/integrations/jira/authentication.clj
+++ b/src/girajira/integrations/jira/authentication.clj
@@ -1,4 +1,4 @@
-(ns girajira.jira.authentication
+(ns girajira.integrations.jira.authentication
   (:require [girajira.config :as config]))
 
 (defn- base-url

--- a/src/girajira/integrations/jira/request.clj
+++ b/src/girajira/integrations/jira/request.clj
@@ -1,6 +1,6 @@
-(ns girajira.jira.request
+(ns girajira.integrations.jira.request
   (:require [clj-http.client :as client]
-            [girajira.jira.authentication :as jira-authentication]
+            [girajira.integrations.jira.authentication :as jira-authentication]
             [cheshire.core :as cheshire]))
 
 (defn jira-api-url

--- a/src/girajira/integrations/jira/transitions.clj
+++ b/src/girajira/integrations/jira/transitions.clj
@@ -1,5 +1,5 @@
-(ns girajira.jira.transitions
-  (:require [girajira.jira.request :as request]
+(ns girajira.integrations.jira.transitions
+  (:require [girajira.integrations.jira.request :as request]
             [clojure.string :as string]))
 
 (defn transitions-url

--- a/test/girajira/api/github/move_jira_issue_test.clj
+++ b/test/girajira/api/github/move_jira_issue_test.clj
@@ -1,7 +1,7 @@
 (ns girajira.api.github.move-jira-issue-test
   (:require [midje.sweet :refer :all]
             [girajira.api.github.move-jira-issue :refer :all]
-            [girajira.jira.transitions :as jira]))
+            [girajira.integrations.jira.transitions :as jira]))
 
 (def opened-pull-request-move-data {:action "opened"
                                     :issue "ca-123"

--- a/test/girajira/config_test.clj
+++ b/test/girajira/config_test.clj
@@ -1,0 +1,10 @@
+(ns girajira.config_test
+  (:require [midje.sweet :refer :all]
+            [girajira.config :refer :all]
+            [aero.core :as aero]))
+
+(facts "when reading secret aero configuration"
+  (fact "it delegates reading of the file to aero"
+    (secrets) => :file-read
+    (provided
+      (aero/read-config "config/.config.edn") => :file-read)))

--- a/test/girajira/integrations/jira/authentication_test.clj
+++ b/test/girajira/integrations/jira/authentication_test.clj
@@ -1,6 +1,6 @@
-(ns girajira.jira.authentication-test
+(ns girajira.integrations.jira.authentication-test
   (:require [midje.sweet :refer :all]
-            [girajira.jira.authentication :refer :all]
+            [girajira.integrations.jira.authentication :refer :all]
             [girajira.config :as config]))
 
 (def secrets

--- a/test/girajira/integrations/jira/request_test.clj
+++ b/test/girajira/integrations/jira/request_test.clj
@@ -1,7 +1,7 @@
-(ns girajira.jira.request-test
+(ns girajira.integrations.jira.request-test
   (:require [midje.sweet :refer :all]
-            [girajira.jira.request :refer :all]
-            [girajira.jira.authentication :as jira-authentication])
+            [girajira.integrations.jira.request :refer :all]
+            [girajira.integrations.jira.authentication :as jira-authentication])
   (:use clj-http.fake))
 
 (facts "when getting the jira api url"


### PR DESCRIPTION
## Changes

- Rename `jira` namespace to `integrations/jira`
- Increase test coverage

## Coverage

- Forms: 77,65%
- Lines: 83,04%
