### PR TITLE
Domain Events with core.async

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,5 +20,5 @@
   :resource-paths ["config"]
   :profiles
   {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
-                        [ring/ring-mock "0.3.0"]
+                        [ring/ring-mock "0.3.2"]
                         [midje "1.9.1"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,9 @@
 (defproject girajira "0.1.0-SNAPSHOT"
   :description "Girajira - github and jira integration for development process automation"
-  :url "http://example.com/FIXME"
+  :url "https://github.com/oborba/girajira"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.474"]
                  [compojure "1.5.1"]
                  [clj-http "3.7.0"]
                  [clj-http-fake "1.0.3"]
@@ -14,7 +15,8 @@
                  [metosin/ring-http-response "0.9.0"]]
   :plugins [[lein-ring "0.9.7"]
             [lein-cloverage "1.0.10"]]
-  :ring {:handler girajira.handler/app}
+  :ring {:handler girajira.handler/app
+         :init girajira.infra.events.initialize/initialize-subscribers}
   :resource-paths ["config"]
   :profiles
   {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
                  [compojure "1.5.1"]
                  [clj-http "3.7.0"]
                  [clj-http-fake "1.0.3"]
+                 [clj-time "0.14.2"]
                  [cheshire "5.8.0"]
                  [aero "1.1.2"]
                  [ring/ring-core "1.6.3"]

--- a/src/girajira/api/github/post.clj
+++ b/src/girajira/api/github/post.clj
@@ -2,7 +2,8 @@
   (:require [clojure.walk :as walk]
             [girajira.api.github.validation :as validation]
             [girajira.api.github.representation :as representation]
-            [girajira.api.github.move-jira-issue :as jira]))
+            [girajira.infra.events.pubsub :as pubsub]
+            [girajira.infra.events.definitions :as events]))
 
 (defn keywordize-request-body
   [request-body]
@@ -44,5 +45,7 @@
   (let [pull-request (pull-request-data (keywordize-request-body request-body))]
     (do
      (if (validation/valid-pull-request? pull-request)
-       (jira/move-issue (move-issue-data pull-request)))
+       (pubsub/publish
+         events/github-pull-request-received
+         (move-issue-data pull-request)))
      (representation/no-content))))

--- a/src/girajira/handler.clj
+++ b/src/girajira/handler.clj
@@ -5,11 +5,13 @@
             [ring.util.response :refer [resource-response response]]
             [ring.middleware.json :as middleware]
             [ring.middleware.defaults :refer [wrap-defaults api-defaults]]
-            [girajira.api.github.post :as github-post]))
+            [girajira.api.github.post :as github-post]
+            [girajira.infra.events.pubsub :as pubsub]))
 
 (defroutes app-routes
   (GET "/" [] "Girajira ;)")
   (GET "/test-json-response" [] (response {:fulano "test"}))
+  (GET "/test-events" [] (pubsub/test-pub-sub))
   (POST "/github/pull-request" {request-body :body} (github-post/handle request-body))
   (route/not-found "Not Found"))
 

--- a/src/girajira/handler.clj
+++ b/src/girajira/handler.clj
@@ -11,7 +11,6 @@
 (defroutes app-routes
   (GET "/" [] "Girajira ;)")
   (GET "/test-json-response" [] (response {:fulano "test"}))
-  (GET "/test-events" [] (pubsub/test-pub-sub))
   (POST "/github/pull-request" {request-body :body} (github-post/handle request-body))
   (route/not-found "Not Found"))
 

--- a/src/girajira/infra/events/datetime.clj
+++ b/src/girajira/infra/events/datetime.clj
@@ -1,0 +1,9 @@
+(ns girajira.infra.events.datetime
+  (:require [clj-time.core :as clj-time]
+            [clj-time.format :as date-format]))
+
+(def formatter (date-format/formatters :date-hour-minute-second-ms))
+
+(defn today []
+  (let [utc-time (clj-time/now)]
+    (date-format/unparse formatter utc-time)))

--- a/src/girajira/infra/events/definitions.clj
+++ b/src/girajira/infra/events/definitions.clj
@@ -1,5 +1,5 @@
 (ns girajira.infra.events.definitions)
 
-(def ^:const sample-event :sample-event)
+(def ^:const example-event :example-event)
 
 (def ^:const github-pull-request-received :github-pull-request-received)

--- a/src/girajira/infra/events/definitions.clj
+++ b/src/girajira/infra/events/definitions.clj
@@ -1,0 +1,5 @@
+(ns girajira.infra.events.definitions)
+
+(def ^:const sample-event :sample-event)
+
+(def ^:const github-pull-request-received :github-pull-request-received)

--- a/src/girajira/infra/events/initialize.clj
+++ b/src/girajira/infra/events/initialize.clj
@@ -1,0 +1,8 @@
+(ns girajira.infra.events.initialize
+  (:require [girajira.infra.events.subscribers.jira-transition :as jira]
+            [girajira.infra.events.subscribers.sample-subscriber :as sample]))
+
+(defn initialize-subscribers []
+  (do
+    (jira/initialize-subscriber)
+    (sample/initialize-subscriber)))

--- a/src/girajira/infra/events/initialize.clj
+++ b/src/girajira/infra/events/initialize.clj
@@ -1,8 +1,8 @@
 (ns girajira.infra.events.initialize
   (:require [girajira.infra.events.subscribers.jira-transition :as jira]
-            [girajira.infra.events.subscribers.sample-subscriber :as sample]))
+            [girajira.infra.events.subscribers.example-subscriber :as example]))
 
 (defn initialize-subscribers []
   (do
     (jira/initialize-subscriber)
-    (sample/initialize-subscriber)))
+    (example/initialize-subscriber)))

--- a/src/girajira/infra/events/pubsub.clj
+++ b/src/girajira/infra/events/pubsub.clj
@@ -1,7 +1,8 @@
 (ns girajira.infra.events.pubsub
   (:require [clojure.core.async
              :as async
-             :refer [>! <! >!! <!! chan go pub sub go-loop]]
+             :refer [>! <! chan go pub sub go-loop]]
+            [girajira.infra.events.datetime :as datetime]
             [girajira.infra.events.definitions :as events]))
 
 (def publisher (chan))
@@ -25,9 +26,10 @@
 (defn publish
   [event data]
   (let [payload {:event event
-                 :time 6}]
+                 :time (datetime/today)
+                 :data data}]
     (go
-      (>! publisher (assoc payload :data data)))))
+      (>! publisher payload))))
 
 (defn test-pub-sub []
   (do

--- a/src/girajira/infra/events/pubsub.clj
+++ b/src/girajira/infra/events/pubsub.clj
@@ -10,7 +10,7 @@
 (def publication
   (pub publisher :event))
 
-(defn- event-handler
+(defn initialize-event-handler
   [channel event-fn]
   (go-loop []
            (let [event (<! channel)]
@@ -21,7 +21,7 @@
   [topic channel event-fn]
   (do
     (sub publication topic channel)
-    (event-handler channel event-fn)))
+    (initialize-event-handler channel event-fn)))
 
 (defn publish
   [event data]
@@ -30,8 +30,3 @@
                  :data data}]
     (go
       (>! publisher payload))))
-
-(defn test-pub-sub []
-  (do
-    (publish events/example-event {:person "test"})
-    "stub render"))

--- a/src/girajira/infra/events/pubsub.clj
+++ b/src/girajira/infra/events/pubsub.clj
@@ -1,0 +1,33 @@
+(ns girajira.infra.events.pubsub
+  (:require [clojure.core.async
+             :as async
+             :refer [>! <! >!! <!! chan go pub sub go-loop]]
+            [girajira.infra.events.definitions :as events]))
+
+(def publisher (chan))
+
+(def publication
+  (pub publisher :event))
+
+(defn- event-handler
+  [channel event-fn]
+  (go-loop []
+           (let [event (<! channel)]
+             (event-fn event))
+           (recur)))
+
+(defn subscribe
+  [topic channel event-fn]
+  (do
+    (sub publication topic channel)
+    (event-handler channel event-fn)))
+
+(defn publish
+  [event data]
+  (go
+    (>! publisher (assoc data :event event))))
+
+(defn test-pub-sub []
+  (do
+    (publish events/sample-event {:person "test"})
+    "stub render"))

--- a/src/girajira/infra/events/pubsub.clj
+++ b/src/girajira/infra/events/pubsub.clj
@@ -24,10 +24,12 @@
 
 (defn publish
   [event data]
-  (go
-    (>! publisher (assoc data :event event))))
+  (let [payload {:event event
+                 :time 6}]
+    (go
+      (>! publisher (assoc payload :data data)))))
 
 (defn test-pub-sub []
   (do
-    (publish events/sample-event {:person "test"})
+    (publish events/example-event {:person "test"})
     "stub render"))

--- a/src/girajira/infra/events/subscribers/example_subscriber.clj
+++ b/src/girajira/infra/events/subscribers/example_subscriber.clj
@@ -1,4 +1,4 @@
-(ns girajira.infra.events.subscribers.sample-subscriber
+(ns girajira.infra.events.subscribers.example-subscriber
   (:require [clojure.core.async :as async :refer [chan]]
             [girajira.infra.events.pubsub :as pubsub]
             [girajira.infra.events.definitions :as events]))
@@ -7,10 +7,10 @@
 
 (defn on-event
   [event]
-  (println (str "hey this is a sample subscriber: " event)))
+  (println (str "Example subscriber: " event)))
 
 (defn initialize-subscriber []
   (pubsub/subscribe
-    events/sample-event
+    events/example-event
     subscriber
     on-event))

--- a/src/girajira/infra/events/subscribers/jira_transition.clj
+++ b/src/girajira/infra/events/subscribers/jira_transition.clj
@@ -8,9 +8,10 @@
 
 (defn on-event
   [event]
-  (do
-    (println (str "jira-transition: " event))
-    (jira/move-issue event)))
+  (let [move-data (:data event)]
+    (do
+      (println (str "jira-transition: " event))
+      (jira/move-issue move-data))))
 
 (defn initialize-subscriber []
   (pubsub/subscribe

--- a/src/girajira/infra/events/subscribers/jira_transition.clj
+++ b/src/girajira/infra/events/subscribers/jira_transition.clj
@@ -1,0 +1,19 @@
+(ns girajira.infra.events.subscribers.jira-transition
+  (:require [clojure.core.async :as async :refer [chan]]
+            [girajira.infra.events.pubsub :as pubsub]
+            [girajira.infra.events.definitions :as events]
+            [girajira.integrations.jira.move-issue :as jira]))
+
+(def subscriber (chan))
+
+(defn on-event
+  [event]
+  (do
+    (println (str "jira-transition: " event))
+    (jira/move-issue event)))
+
+(defn initialize-subscriber []
+  (pubsub/subscribe
+    events/github-pull-request-received
+    subscriber
+    on-event))

--- a/src/girajira/infra/events/subscribers/sample_subscriber.clj
+++ b/src/girajira/infra/events/subscribers/sample_subscriber.clj
@@ -1,0 +1,16 @@
+(ns girajira.infra.events.subscribers.sample-subscriber
+  (:require [clojure.core.async :as async :refer [chan]]
+            [girajira.infra.events.pubsub :as pubsub]
+            [girajira.infra.events.definitions :as events]))
+
+(def subscriber (chan))
+
+(defn on-event
+  [event]
+  (println (str "hey this is a sample subscriber: " event)))
+
+(defn initialize-subscriber []
+  (pubsub/subscribe
+    events/sample-event
+    subscriber
+    on-event))

--- a/src/girajira/integrations/jira/move_issue.clj
+++ b/src/girajira/integrations/jira/move_issue.clj
@@ -1,4 +1,4 @@
-(ns girajira.api.github.move-jira-issue
+(ns girajira.integrations.jira.move-issue
   (:require [girajira.integrations.jira.transitions :as jira]))
 
 (defn- move-to-column

--- a/test/girajira/api/github/post_test.clj
+++ b/test/girajira/api/github/post_test.clj
@@ -2,7 +2,8 @@
   (:require [midje.sweet :refer :all]
             [girajira.api.github.post :refer :all]
             [girajira.api.github.representation :as representation]
-            [girajira.api.github.move-jira-issue :as jira]))
+            [girajira.infra.events.pubsub :as pubsub]
+            [girajira.infra.events.definitions :as events]))
 
 (def opened-payload
   {"action" "opened"
@@ -72,18 +73,22 @@
   (fact "it moves the jira issue and returns http status 204 no content"
     (handle opened-payload) => 204
     (provided
-      (jira/move-issue {:action "opened"
-                        :issue "ca-123"
-                        :columns {:open "doing done"
-                                  :merge "done"}}) => :ok
+      (pubsub/publish
+        events/github-pull-request-received
+        {:action "opened"
+         :issue "ca-123"
+         :columns {:open "doing done"
+                   :merge "done"}}) => :ok
       (representation/no-content) => 204)))
 
 (facts "when handling the post request given a merged pull request"
   (fact "it moves the jira issue and returns http status 204 no content"
     (handle merged-payload) => 204
     (provided
-      (jira/move-issue {:action "merged"
-                        :issue "ca-123"
-                        :columns {:open "doing done"
-                                  :merge "done"}}) => :ok
+      (pubsub/publish
+        events/github-pull-request-received
+        {:action "merged"
+         :issue "ca-123"
+         :columns {:open "doing done"
+                   :merge "done"}}) => :ok
       (representation/no-content) => 204)))

--- a/test/girajira/handler_test.clj
+++ b/test/girajira/handler_test.clj
@@ -3,10 +3,13 @@
             [midje.sweet :refer :all]
             [girajira.handler :refer :all]))
 
-(fact "responds to /"
-  (let [response (app (mock/request :get "/"))]
-    (:body response) => "Girajira ;)"
-    (:status response) => 200))
+(facts "when responding to routes"
+  (facts "when responding to /"
+    (fact "it returns http status 200"
+      (let [response (app (mock/request :get "/"))]
+        (:body response) => "Girajira ;)"
+        (:status response) => 200))))
 
-(fact "invalid route responds 404"
-  (:status (app (mock/request :get "/invalid"))) => 404)
+(facts "when responding to invalid routes"
+  (fact "it returns http status 404"
+    (:status (app (mock/request :get "/invalid"))) => 404))

--- a/test/girajira/handler_test.clj
+++ b/test/girajira/handler_test.clj
@@ -8,7 +8,13 @@
     (fact "it returns http status 200"
       (let [response (app (mock/request :get "/"))]
         (:body response) => "Girajira ;)"
-        (:status response) => 200))))
+        (:status response) => 200)))
+
+  (facts "when responding to /github/pull-request"
+    (fact "it returns http status 204"
+      (let [response (app (-> (mock/request :post "/github/pull-request")
+                              (mock/json-body {:fake "data"})))]
+        (:status response) => 204))))
 
 (facts "when responding to invalid routes"
   (fact "it returns http status 404"

--- a/test/girajira/infra/events/datetime_test.clj
+++ b/test/girajira/infra/events/datetime_test.clj
@@ -1,0 +1,10 @@
+(ns girajira.infra.events.datetime-test
+  (:require [midje.sweet :refer :all]
+            [girajira.infra.events.datetime :refer :all]
+            [clj-time.core :as clj-time]))
+
+(facts "when calculating today's date"
+  (fact "it returns a string representation of today's date"
+    (today) => "2018-12-01T14:00:00.000"
+    (provided
+      (clj-time/now) => (clj-time/date-time 2018 12 01 14 0 0))))

--- a/test/girajira/infra/events/initialize_test.clj
+++ b/test/girajira/infra/events/initialize_test.clj
@@ -1,0 +1,12 @@
+(ns girajira.infra.events.initialize-test
+  (:require [midje.sweet :refer :all]
+            [girajira.infra.events.initialize :refer :all]
+            [girajira.infra.events.subscribers.jira-transition :as jira]
+            [girajira.infra.events.subscribers.example-subscriber :as example]))
+
+(facts "when initializing subscribers"
+  (fact "it initializes all event subscribers"
+    (initialize-subscribers) => :initialize-example-subscriber
+    (provided
+      (jira/initialize-subscriber) => :initialize-jira-subscriber
+      (example/initialize-subscriber) => :initialize-example-subscriber)))

--- a/test/girajira/infra/events/pubsub_test.clj
+++ b/test/girajira/infra/events/pubsub_test.clj
@@ -1,0 +1,22 @@
+(ns girajira.infra.events.pubsub-test
+  (:require [midje.sweet :refer :all]
+            [girajira.infra.events.pubsub :refer :all]
+            [girajira.infra.events.datetime :as datetime]
+            [clojure.core.async :as async]))
+
+(facts "when subscribing to a topic given a channel and callback function"
+  (fact "it subscribes to a publication given the topic and a channel and sets up an event handler"
+    (with-redefs [publication ..publication..]
+      (subscribe ..topic.. ..channel.. ..callback..) => ..subscription..
+        (provided
+          (async/sub ..publication.. ..topic.. ..channel..) => ..many-to-many-channel..
+          (initialize-event-handler ..channel.. ..callback..) => ..subscription..))))
+
+(facts "when publishing an event with some data"
+  (fact "it puts the event data on a channel"
+    (with-redefs [publisher (async/chan)
+                  datetime/today (fn [] ..current-time..)]
+      (let [blocking-read (fn [] (async/<!! publisher))]
+        (do
+          (publish ..event.. ..data..)
+          (blocking-read) => {:event ..event.. :time ..current-time.. :data ..data..})))))

--- a/test/girajira/infra/events/subscribers/example_subscriber_test.clj
+++ b/test/girajira/infra/events/subscribers/example_subscriber_test.clj
@@ -1,0 +1,15 @@
+(ns girajira.infra.events.subscribers.example-subscriber-test
+  (:require [midje.sweet :refer :all]
+            [girajira.infra.events.subscribers.example-subscriber :refer :all]
+            [girajira.infra.events.pubsub :as pubsub]))
+
+(facts "when initializing the subscriber"
+  (fact "it calls subscribe passing the correct event, subscriber channel and event handler"
+    (with-redefs [subscriber ..fake-channel..
+                  on-event ..fake-event-handler..]
+      (initialize-subscriber) => ..ok..
+        (provided
+          (pubsub/subscribe
+            :example-event
+            ..fake-channel..
+            ..fake-event-handler..) => ..ok..))))

--- a/test/girajira/infra/events/subscribers/jira_transition_test.clj
+++ b/test/girajira/infra/events/subscribers/jira_transition_test.clj
@@ -1,0 +1,22 @@
+(ns girajira.infra.events.subscribers.jira-transition-test
+  (:require [midje.sweet :refer :all]
+            [girajira.infra.events.subscribers.jira-transition :refer :all]
+            [girajira.infra.events.pubsub :as pubsub]
+            [girajira.integrations.jira.move-issue :as jira]))
+
+(facts "when running the event handler"
+  (fact "it calls the move-issue function"
+    (on-event {:data "fake event data"}) => ..ok..
+    (provided
+      (jira/move-issue "fake event data") => ..ok..)))
+
+(facts "when initializing the subscriber"
+  (fact "it calls subscribe passing the correct event, subscriber channel and event handler"
+    (with-redefs [subscriber ..fake-channel..
+                  on-event ..fake-event-handler..]
+      (initialize-subscriber) => ..ok..
+        (provided
+          (pubsub/subscribe
+            :github-pull-request-received
+            ..fake-channel..
+            ..fake-event-handler..) => ..ok..))))

--- a/test/girajira/integrations/jira/move_issue_test.clj
+++ b/test/girajira/integrations/jira/move_issue_test.clj
@@ -1,6 +1,6 @@
-(ns girajira.api.github.move-jira-issue-test
+(ns girajira.integrations.jira.move-issue-test
   (:require [midje.sweet :refer :all]
-            [girajira.api.github.move-jira-issue :refer :all]
+            [girajira.integrations.jira.move-issue :refer :all]
             [girajira.integrations.jira.transitions :as jira]))
 
 (def opened-pull-request-move-data {:action "opened"


### PR DESCRIPTION
## Changes
Implement a `publish-subscribe` messaging pattern using `core.async`

A `pubsub` pattern allows us to completely decouple the Github API from the Jira integration. This gives us the possibility to have future integrations subscribe to existing events (e.g. some google sheet integration) in order to allow different use cases to be executed in parallel.

Instead of directly calling the Jira integration from within the Github namespace as we were doing
```clojure
(if (validation/valid-pull-request? pull-request)
  (jira/move-issue (move-issue-data pull-request)))
```

We now publish a github pull request event like so
```clojure
(if (validation/valid-pull-request? pull-request)
  (pubsub/publish
    events/github-pull-request-received
    (move-issue-data pull-request)))
```

Any subscriber interested in `events/github-pull-request-received` should subscribe to said event and implement an event-handler to do something interesting whenever the event is received.